### PR TITLE
whitelist set via args not json list

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ wireleap config address.socks
 
 # set the address of the connection broker (requires daemon restart)
 wireleap config address.socks 127.0.0.1:3434
+
+# to whitelist only the relays known as "foo" and "bar"
+wireleap config circuit.whitelist 'wireleap://foo:1234' 'wireleap://bar:4321'
 ```
 
 After changing configuration options via `wireleap config`, the changes
@@ -178,7 +181,7 @@ specific amount of hops, or a more general *only use these relays*.
 wireleap config circuit.hops 1
 
 # set a whitelist of relays to use
-wireleap config circuit.whitelist '["wireleap://relay1.example.com:13490"]'
+wireleap config circuit.whitelist "wireleap://relay1.example.com:13490"
 
 # manually trigger new circuit generation
 wireleap reload

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ wireleap config address.socks
 wireleap config address.socks 127.0.0.1:3434
 
 # to whitelist only the relays known as "foo" and "bar"
-wireleap config circuit.whitelist 'wireleap://foo:1234' 'wireleap://bar:4321'
+wireleap config circuit.whitelist "wireleap://foo:1234" "wireleap://bar:4321"
 ```
 
 After changing configuration options via `wireleap config`, the changes

--- a/sub/configcmd/configcmd.go
+++ b/sub/configcmd/configcmd.go
@@ -35,7 +35,7 @@ func Cmd(fm0 fsdir.T) *cli.Subcmd {
 		val := fs.Arg(1)
 		vals := fs.Args()[1:]
 
-		if key == "" || (key != "circuit.whitelist" && fs.NArg() > 2) {
+		if key == "" {
 			r.Usage()
 		}
 
@@ -49,6 +49,11 @@ func Cmd(fm0 fsdir.T) *cli.Subcmd {
 				break
 			}
 		}
+
+		if val_type != "list" && fs.NArg() > 2 {
+			r.Usage()
+		}
+
 		if val_type == "list" && len(vals) > 0 {
 			if vals[0] == "null" {
 				val = vals[0]

--- a/sub/configcmd/configcmd.go
+++ b/sub/configcmd/configcmd.go
@@ -27,17 +27,29 @@ func Cmd(fm0 fsdir.T) *cli.Subcmd {
 	}
 
 	r.Run = func(fm fsdir.T) {
-		if fs.NArg() < 1 || fs.NArg() > 2 {
+		if fs.NArg() < 1 {
 			r.Usage()
 		}
 
 		key := fs.Arg(0)
 		val := fs.Arg(1)
+		vals := fs.Args()[1:]
 
-		if key == "" {
+		if key == "" || (key != "circuit.whitelist" && fs.NArg() > 2) {
 			r.Usage()
 		}
 
+		// pre-processing val list for circuit.whitelist to be in-line with all
+		// other arguments
+		if key == "circuit.whitelist" && len(vals) > 0 {
+			val_bytes, err := json.Marshal(&vals)
+			if err != nil {
+				log.Fatalf(
+					"could not marshal values for `circuit.whitelist`: %s",
+					err)
+			}
+			val = string(val_bytes)
+		}
 		Run(fm, key, val)
 	}
 

--- a/sub/configcmd/configcmd.go
+++ b/sub/configcmd/configcmd.go
@@ -39,9 +39,17 @@ func Cmd(fm0 fsdir.T) *cli.Subcmd {
 			r.Usage()
 		}
 
-		// pre-processing val list for circuit.whitelist to be in-line with all
-		// other arguments
-		if key == "circuit.whitelist" && len(vals) > 0 {
+		// pre-processing val list for all "list" type config items to be in-line
+		// with all other arguments
+		var val_type string
+		c := clientcfg.Defaults()
+		for _, meta := range c.Metadata() {
+			if meta.Name == key {
+				val_type = meta.Type
+				break
+			}
+		}
+		if val_type == "list" && len(vals) > 0 {
 			val_bytes, err := json.Marshal(&vals)
 			if err != nil {
 				log.Fatalf(

--- a/sub/configcmd/configcmd.go
+++ b/sub/configcmd/configcmd.go
@@ -50,13 +50,17 @@ func Cmd(fm0 fsdir.T) *cli.Subcmd {
 			}
 		}
 		if val_type == "list" && len(vals) > 0 {
-			val_bytes, err := json.Marshal(&vals)
-			if err != nil {
-				log.Fatalf(
-					"could not marshal values for `circuit.whitelist`: %s",
-					err)
+			if vals[0] == "null" {
+				val = vals[0]
+			} else {
+				val_bytes, err := json.Marshal(&vals)
+				if err != nil {
+					log.Fatalf(
+						"could not marshal values for `circuit.whitelist`: %s",
+						err)
+				}
+				val = string(val_bytes)
 			}
-			val = string(val_bytes)
 		}
 		Run(fm, key, val)
 	}


### PR DESCRIPTION
Allows 

```bash
    wireleap config circuit.whitelist "address1" "address2"
```

instead of requiring

```bash
    wireleap config circuit.whitelist '["address1", "address2"]'
```

only applies to whitelist