### PR TITLE
bump common dependency to 0.2.1

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,6 +1,6 @@
 # 0.4.0
 
-- Depends on `wireleap/common` v0.2.0.
+- Depends on `wireleap/common` v0.2.1.
 - Improved `bypass.json` generation logic to cover edge cases.
 - Improved SKSource synchronization to avoid race conditions.
 - Added `firefox` exec script.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/vishvananda/netlink v1.1.0
-	github.com/wireleap/common v0.2.0
+	github.com/wireleap/common v0.2.1
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJ
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/wireleap/common v0.2.0 h1:qsVXxnPm6oc9H0ztywNfV3eVT0JfNIerPNW+TSKH/LM=
-github.com/wireleap/common v0.2.0/go.mod h1:fkkbj+/ivixHoxo/Bie5JrS5eaSfCXGqvdXfWvd6PnA=
+github.com/wireleap/common v0.2.1 h1:F+iESNqkyBXtc8K+HRVc1+XAvdzbuoJNnq6Zf1a0UY0=
+github.com/wireleap/common v0.2.1/go.mod h1:fkkbj+/ivixHoxo/Bie5JrS5eaSfCXGqvdXfWvd6PnA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=


### PR DESCRIPTION
avoids issues with the golang checksum cache